### PR TITLE
fix: Handling CalledProcessError when getting the POD IP

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,7 @@
 
 import logging
 from ipaddress import IPv4Address
-from subprocess import check_output
+from subprocess import CalledProcessError, check_output
 from typing import Optional
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # type: ignore[import]
@@ -455,8 +455,11 @@ def _get_pod_ip() -> Optional[str]:
     Returns:
         str: The pod IP.
     """
-    ip_address = check_output(["unit-get", "private-address"])
-    return str(IPv4Address(ip_address.decode().strip())) if ip_address else None
+    try:
+        ip_address = check_output(["unit-get", "private-address"])
+        return str(IPv4Address(ip_address.decode().strip())) if ip_address else None
+    except (CalledProcessError, ValueError):
+        return None
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
# Description

Adds handling for `CalledProcessError` when getting POD IP to prevent `Uncaught exception while in charm code`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library