### PR TITLE
feat: Store authentication keys in a separate database

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ juju deploy sdcore-nrf-k8s --channel=edge
 juju deploy sdcore-udr-k8s --channel=edge
 juju deploy self-signed-certificates --channel=beta
 juju integrate mongodb-k8s sdcore-nrf-k8s
-juju integrate mongodb-k8s sdcore-udr-k8s:database
+juju integrate mongodb-k8s sdcore-udr-k8s:common_database
+juju integrate mongodb-k8s sdcore-udr-k8s:auth_database
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:fiveg_nrf sdcore-udr-k8s:fiveg_nrf
 juju integrate sdcore-udr-k8s:certificates self-signed-certificates:certificates

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,9 @@ containers:
         location: /support/TLS
 
 requires:
-  database:
+  common_database:
+    interface: mongodb_client
+  auth_database:
     interface: mongodb_client
   fiveg_nrf:
     interface: fiveg_nrf

--- a/src/templates/udrcfg.yaml.j2
+++ b/src/templates/udrcfg.yaml.j2
@@ -9,8 +9,10 @@ configuration:
     bindingIPv4: 0.0.0.0
     port: {{ udr_sbi_port }}
   mongodb:
-    name: {{ default_database_name }}
-    url: {{ default_database_url }}
+    name: {{ common_database_name }}
+    url: {{ common_database_url }}
+    authKeysDbName: {{ auth_database_name }}
+    authUrl: {{ auth_database_url }}
   nrfUri: {{ nrf_url }}
 
 # the kind of log output

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,12 +30,12 @@ module "sdcore-udr-k8s" {
 Create the integrations, for instance:
 
 ```text
-resource "juju_integration" "udr-db" {
+resource "juju_integration" "udr-common-db" {
   model = var.model_name
 
   application {
     name     = module.udr.app_name
-    endpoint = module.udr.database_endpoint
+    endpoint = module.udr.commmon_database_endpoint
   }
 
   application {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,9 +6,14 @@ output "app_name" {
   value       = juju_application.sdcore-udr-k8s.name
 }
 
-output "database_endpoint" {
-  description = "Name of the endpoint to integrate with MongoDB using mongodb_client interface."
-  value       = "database"
+output "common_database_endpoint" {
+  description = "Name of the endpoint to integrate with MongoDB for common_database using mongodb_client interface."
+  value       = "common_database"
+}
+
+output "auth_database_endpoint" {
+  description = "Name of the endpoint to integrate with MongoDB for auth_database using mongodb_client interface."
+  value       = "auth_database"
 }
 
 output "fiveg_nrf_endpoint" {

--- a/tests/unit/resources/expected_udrcfg.yaml
+++ b/tests/unit/resources/expected_udrcfg.yaml
@@ -10,7 +10,9 @@ configuration:
     port: 29504
   mongodb:
     name: free5gc
-    url: http://dummy
+    url: 1.9.11.4:1234
+    authKeysDbName: authentication
+    authUrl: 1.9.11.4:1234
   nrfUri: http://nrf:8081
 
 # the kind of log output


### PR DESCRIPTION
# Description

The upstream [PR](https://github.com/omec-project/udr/pull/63) requires changes in the charm to use  the second database. 
The upstream PR is merged. This PR has a dependency to https://github.com/canonical/sdcore-udr-rock/pull/13 which updates webconsole image.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library