### PR TITLE
chore: Use Ops.CollectStatus Event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ign
     generate_private_key,
 )
 from jinja2 import Environment, FileSystemLoader
-from ops import ActiveStatus, BlockedStatus, RelationBrokenEvent, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, RelationBrokenEvent, WaitingStatus
 from ops.charm import CharmBase, EventBase
 from ops.main import main
 from ops.pebble import Layer, PathError
@@ -57,6 +57,7 @@ class UDROperatorCharm(CharmBase):
         self._auth_database = DatabaseRequires(
             self, relation_name=AUTH_DATABASE_RELATION_NAME, database_name=AUTH_DATABASE_NAME
         )
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         self.unit.set_ports(UDR_SBI_PORT)
         self._certificates = TLSCertificatesRequiresV3(self, TLS_RELATION_NAME)
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
@@ -84,8 +85,12 @@ class UDROperatorCharm(CharmBase):
             self._certificates.on.certificate_expiring, self._on_certificate_expiring
         )
 
-    def ready_to_configure(self) -> bool:
-        """Returns whether the preconditions are met to proceed with configuration."""
+    def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
+        """Check the unit status and set to Unit when CollectStatusEvent is fired.
+
+        Args:
+            event: CollectStatusEvent
+        """
         for relation in [
             COMMON_DATABASE_RELATION_NAME,
             AUTH_DATABASE_RELATION_NAME,
@@ -93,26 +98,74 @@ class UDROperatorCharm(CharmBase):
             TLS_RELATION_NAME,
         ]:
             if not self._relation_created(relation):
-                self.unit.status = BlockedStatus(
-                    f"Waiting for the {relation} relation to be created"
+                event.add_status(
+                    BlockedStatus(f"Waiting for the {relation} relation to be created")
                 )
+                return
+
+        if not self._common_database_is_available():
+            event.add_status(WaitingStatus("Waiting for the common database to be available"))
+            return
+
+        if not self._auth_database_is_available():
+            event.add_status(
+                WaitingStatus("Waiting for the authentication database to be available")
+            )
+            return
+
+        if not self._get_common_database_url():
+            event.add_status(WaitingStatus("Waiting for the common database url to be available"))
+            return
+
+        if not self._get_auth_database_url():
+            event.add_status(WaitingStatus("Waiting for the auth database url to be available"))
+            return
+
+        if not self._nrf_is_available():
+            event.add_status(WaitingStatus("Waiting for the NRF to be available"))
+            return
+
+        if not self._container.can_connect():
+            event.add_status(WaitingStatus("Waiting for the container to be ready"))
+            return
+
+        if not self._storage_is_attached():
+            event.add_status(WaitingStatus("Waiting for the storage to be attached"))
+            return
+
+        if not _get_pod_ip():
+            event.add_status(WaitingStatus("Waiting for pod IP address to be available"))
+            return
+
+        if self._csr_is_stored() and not self._get_current_provider_certificate():
+            event.add_status(WaitingStatus("Waiting for certificates to be stored"))
+            return
+
+        event.add_status(ActiveStatus())
+
+    def ready_to_configure(self) -> bool:
+        """Returns whether the preconditions are met to proceed with the configuration.
+
+        Returns:
+            ready_to_configure: True if all conditions are met else False
+        """
+        for relation in [
+            COMMON_DATABASE_RELATION_NAME,
+            AUTH_DATABASE_RELATION_NAME,
+            NRF_RELATION_NAME,
+            TLS_RELATION_NAME,
+        ]:
+            if not self._relation_created(relation):
                 return False
         if not self._common_database_is_available():
-            self.unit.status = WaitingStatus("Waiting for the common database to be available")
             return False
         if not self._auth_database_is_available():
-            self.unit.status = WaitingStatus(
-                "Waiting for the authentication database to be available"
-            )
             return False
         if not self._get_common_database_url():
-            self.unit.status = WaitingStatus("Waiting for the common database url to be available")
             return False
         if not self._get_auth_database_url():
-            self.unit.status = WaitingStatus("Waiting for the auth database url to be available")
             return False
         if not self._nrf_is_available():
-            self.unit.status = WaitingStatus("Waiting for the NRF to be available")
             return False
         return True
 
@@ -128,15 +181,11 @@ class UDROperatorCharm(CharmBase):
         if not self.ready_to_configure():
             return
         if not self._container.can_connect():
-            self.unit.status = WaitingStatus("Waiting for the container to be ready")
             return
         if not self._storage_is_attached():
-            self.unit.status = WaitingStatus("Waiting for the storage to be attached")
             return
         if not _get_pod_ip():
-            self.unit.status = WaitingStatus("Waiting for pod IP address to be available")
             return
-
         if not self._private_key_is_stored():
             self._generate_private_key()
 
@@ -145,7 +194,6 @@ class UDROperatorCharm(CharmBase):
 
         provider_certificate = self._get_current_provider_certificate()
         if not provider_certificate:
-            self.unit.status = WaitingStatus("Waiting for certificates to be stored")
             return
 
         if certificate_update_required := self._is_certificate_update_required(
@@ -159,7 +207,6 @@ class UDROperatorCharm(CharmBase):
 
         should_restart = config_update_required or certificate_update_required
         self._configure_pebble(restart=should_restart)
-        self.unit.status = ActiveStatus()
 
     def _on_nrf_broken(self, event: RelationBrokenEvent) -> None:
         """Event handler for NRF relation broken.
@@ -167,7 +214,7 @@ class UDROperatorCharm(CharmBase):
         Args:
             event (NRFBrokenEvent): Juju event
         """
-        self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
+        logger.info("Waiting for fiveg_nrf relation")
 
     def _on_common_database_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Event handler for common database relation broken.
@@ -176,9 +223,7 @@ class UDROperatorCharm(CharmBase):
             event: Juju event
         """
         if not self.model.relations[COMMON_DATABASE_RELATION_NAME]:
-            self.unit.status = BlockedStatus(
-                f"Waiting for {COMMON_DATABASE_RELATION_NAME} relation"
-            )
+            logger.info(f"Waiting for {COMMON_DATABASE_RELATION_NAME} relation")
 
     def _on_auth_database_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Event handler for auth database relation broken.
@@ -187,7 +232,7 @@ class UDROperatorCharm(CharmBase):
             event: Juju event
         """
         if not self.model.relations[AUTH_DATABASE_RELATION_NAME]:
-            self.unit.status = BlockedStatus(f"Waiting for {AUTH_DATABASE_RELATION_NAME} relation")
+            logger.info(f"Waiting for {AUTH_DATABASE_RELATION_NAME} relation")
 
     def _on_certificates_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Deletes TLS related artifacts and reconfigures workload."""
@@ -197,7 +242,6 @@ class UDROperatorCharm(CharmBase):
         self._delete_private_key()
         self._delete_csr()
         self._delete_certificate()
-        self.unit.status = BlockedStatus("Waiting for certificates relation")
 
     def _get_current_provider_certificate(self) -> str | None:
         """Compares the current certificate request to what is in the interface.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,8 +9,7 @@ import yaml
 from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
     ProviderCertificate,
 )
-from ops import testing
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 
 from charm import NRF_RELATION_NAME, TLS_RELATION_NAME, UDROperatorCharm
 
@@ -155,6 +154,7 @@ class TestCharm(unittest.TestCase):
     ):
         self._create_nrf_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for the common_database relation to be created"),
@@ -169,6 +169,7 @@ class TestCharm(unittest.TestCase):
         )
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for the auth_database relation to be created"),
@@ -183,6 +184,7 @@ class TestCharm(unittest.TestCase):
             relation_name=AUTH_DATABASE_RELATION_NAME, remote_app="some_db_app"
         )
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for the fiveg_nrf relation to be created"),
@@ -199,6 +201,7 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.add_relation(relation_name=NRF_RELATION_NAME, remote_app="some_nrf_app")
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for the certificates relation to be created"),
@@ -227,10 +230,10 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(self.container_name)
 
         self.harness.remove_relation(nrf_relation_id)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
+            BlockedStatus("Waiting for the fiveg_nrf relation to be created"),
         )
 
     @patch("charm.check_output")
@@ -257,10 +260,10 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(self.container_name)
 
         self.harness.remove_relation(database_relation_id)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for common_database relation"),
+            BlockedStatus("Waiting for the common_database relation to be created"),
         )
 
     def test_given_relations_created_but_common_database_not_available_when_pebble_ready_then_status_is_waiting(  # noqa: E501
@@ -275,6 +278,7 @@ class TestCharm(unittest.TestCase):
         self._create_nrf_relation()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for the common database to be available"),
@@ -294,6 +298,7 @@ class TestCharm(unittest.TestCase):
         self._create_nrf_relation()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for the common database url to be available"),
@@ -309,6 +314,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for the NRF to be available")
         )
@@ -325,6 +331,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for the storage to be attached")
         )
@@ -351,6 +358,7 @@ class TestCharm(unittest.TestCase):
         self._create_certificates_relation()
 
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
         )
@@ -394,7 +402,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
-
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
         with open("tests/unit/resources/expected_udrcfg.yaml") as expected_config_file:
             expected_content = expected_config_file.read()
@@ -476,7 +484,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
-
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
 
         patch_restart.assert_called_with(self.container_name)
@@ -524,7 +532,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
-
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
 
         patch_restart.assert_not_called()
@@ -572,6 +580,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
 
         updated_plan = self.harness.get_container_pebble_plan("udr").to_dict()
@@ -615,6 +624,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             ActiveStatus(),
@@ -657,6 +667,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for pod IP address to be available"),
@@ -700,6 +711,7 @@ class TestCharm(unittest.TestCase):
         self._create_auth_database_relation_and_populate_data()
         self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for pod IP address to be available"),


### PR DESCRIPTION
# Description

This PR uses new ops feature CollectStatus Event to manage status Charm. Event named collect_unit_status sets the status of charm automatically at the end of every hook.

Reference:

    https://ops.readthedocs.io/en/latest/#ops.CollectStatusEvent
    https://discourse.charmhub.io/t/how-to-set-a-charms-status/11771


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library