### PR TITLE
fix: remove unnecessary back call when relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -79,13 +79,10 @@ class UDROperatorCharm(CharmBase):
         self.framework.observe(self.on.udr_pebble_ready, self._configure_udr)
         self.framework.observe(self.on.common_database_relation_joined, self._configure_udr)
         self.framework.observe(self.on.auth_database_relation_joined, self._configure_udr)
-        self.framework.observe(self.on.common_database_relation_broken, self._configure_udr)
-        self.framework.observe(self.on.auth_database_relation_broken, self._configure_udr)
         self.framework.observe(self._common_database.on.database_created, self._configure_udr)
         self.framework.observe(self._auth_database.on.database_created, self._configure_udr)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_udr)
         self.framework.observe(self._nrf.on.nrf_available, self._configure_udr)
-        self.framework.observe(self._nrf.on.nrf_broken, self._configure_udr)
         self.framework.observe(self.on.certificates_relation_joined, self._configure_udr)
         self.framework.observe(
             self.on.certificates_relation_broken, self._on_certificates_relation_broken


### PR DESCRIPTION
# Description

In case of a broken relation event, the call to `_configure_udr` returns immediately due to the missing relations and does not perform any configuration. 
It can be removed.
Blocked status is automatically set by the collect uni status event.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library