### PR TITLE
fix: Replacing release with branch name for v0.0 workflows

### DIFF
--- a/.github/workflows/1_4_scheduled_runs.yaml
+++ b/.github/workflows/1_4_scheduled_runs.yaml
@@ -7,39 +7,39 @@ on:
 jobs:
   codeql:
     name: CodeQL Analysis
-    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v1.0.0
+    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v0.0
     with:
       branch-name: "v1.4"
 
   lint-report:
-    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v1.0.0
+    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v0.0
     with:
       branch-name: "v1.4"
 
   terraform-check:
-    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v1.0.0
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v0.0
     with:
       branch-name: "v1.4"
 
   static-analysis:
-    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v1.0.0
+    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v0.0
     with:
       branch-name: "v1.4"
 
   unit-tests-with-coverage:
-    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v1.0.0
+    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v0.0
     with:
       branch-name: "v1.4"
 
   integration-test:
-    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@v1.0.0
+    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@v0.0
     with:
       branch-name: "v1.4"
       charm-file-name: "sdcore-udr-k8s_ubuntu-22.04-amd64.charm"
 
   update-libs:
     name: Update libs
-    uses: canonical/sdcore-github-workflows/.github/workflows/update-libs.yaml@v1.0.0
+    uses: canonical/sdcore-github-workflows/.github/workflows/update-libs.yaml@v0.0
     with:
       branch-name: "v1.4"
     secrets: inherit


### PR DESCRIPTION
# Description

Replacing release with branch name for shared workflows in 1.4 scheduled runs to avoid updates from Dependabot

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library