### PR TITLE
fix: Uses Juju Terraform provider >= 0.11.0

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.11.0"
     }
   }
 }


### PR DESCRIPTION
# Description

Uses Juju Terraform provider `>= 0.11.0`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library