### PR TITLE
chore: replace ops.main.main() with ops.main

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -32,10 +32,10 @@ from ops import (
     ModelError,
     RelationBrokenEvent,
     WaitingStatus,
+    main,
 )
 from ops.charm import CharmBase
 from ops.framework import EventBase
-from ops.main import main
 from ops.pebble import Layer, PathError
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Description

`ops.main.main()` is deprecated. Here, we replace it with `ops.main()`.

## Logs

```
/var/lib/juju/agents/unit-gnbsim-0/charm/./src/charm.py:510: DeprecationWarning: Calling ops.main.main() is deprecated, call ops.main() instead
  main(GNBSIMOperatorCharm)
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library