### PR TITLE
feat: add alert rule for UDR availability

### DIFF
--- a/src/prometheus_alert_rules/udr_down.rule
+++ b/src/prometheus_alert_rules/udr_down.rule
@@ -1,0 +1,8 @@
+alert: UdrDown
+expr: up == 0
+for: 5m
+labels:
+    severity: critical
+annotations:
+    summary: "UDR availability"
+    description: "UDR is unavailable"


### PR DESCRIPTION
# Description

This PR aims to add the alert rule for UDR availability. The alert will be fired when UDR remains down for at least 5 minutes.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library