### PR TITLE
chore: bump rock image to fix grpc client reconnection issues

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -42,7 +42,7 @@ resources:
   udr-image:
     type: oci-image
     description: OCI image for SD-Core's UDR
-    upstream-source: ghcr.io/canonical/sdcore-udr:1.4.1
+    upstream-source: ghcr.io/canonical/sdcore-udr:1.6.1
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,7 @@ NRF_RELATION_NAME = "fiveg_nrf"
 TLS_RELATION_NAME = "certificates"
 UDR_CONFIG_FILE_NAME = "udrcfg.yaml"
 UDR_SBI_PORT = 29504
-CERTS_DIR_PATH = "/support/TLS"  # Certificate paths are hardcoded in UDR code
+CERTS_DIR_PATH = "/support/TLS"
 PRIVATE_KEY_NAME = "udr.key"
 CERTIFICATE_NAME = "udr.pem"
 CERTIFICATE_COMMON_NAME = "udr.sdcore"
@@ -438,6 +438,8 @@ class UDROperatorCharm(CharmBase):
             nrf_url=self._nrf.nrf_url,
             scheme="https",
             webui_uri=self._webui_requires.webui_url,
+            tls_pem=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}",
+            tls_key=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}"
         )
 
     def _is_config_update_required(self, content: str) -> bool:
@@ -483,6 +485,8 @@ class UDROperatorCharm(CharmBase):
         nrf_url: str,
         scheme: str,
         webui_uri: str,
+        tls_pem: str,
+        tls_key: str,
     ) -> str:
         """Render the config file content.
 
@@ -496,6 +500,8 @@ class UDROperatorCharm(CharmBase):
             nrf_url (str): NRF URL.
             scheme (str): SBI interface scheme ("http" or "https")
             webui_uri (str) : URL of the Webui
+            tls_pem (str): TLS certificate file.
+            tls_key (str): TLS key file.
 
         Returns:
             str: Config file content.
@@ -512,6 +518,8 @@ class UDROperatorCharm(CharmBase):
             nrf_url=nrf_url,
             scheme=scheme,
             webui_uri=webui_uri,
+            tls_pem=tls_pem,
+            tls_key=tls_key,
         )
 
     def _config_file_is_written(self) -> bool:

--- a/src/charm.py
+++ b/src/charm.py
@@ -616,7 +616,7 @@ class UDROperatorCharm(CharmBase):
                         "override": "replace",
                         "startup": "enabled",
                         "command": "/bin/udr "
-                        f"-udrcfg {BASE_CONFIG_PATH}/{UDR_CONFIG_FILE_NAME}",
+                        f"-cfg {BASE_CONFIG_PATH}/{UDR_CONFIG_FILE_NAME}",
                         "environment": self._environment_variables,
                     }
                 },

--- a/src/templates/udrcfg.yaml.j2
+++ b/src/templates/udrcfg.yaml.j2
@@ -8,6 +8,9 @@ configuration:
     registerIPv4: {{ udr_ip_address }}
     bindingIPv4: 0.0.0.0
     port: {{ udr_sbi_port }}
+    tls:
+      pem: {{ tls_pem }}
+      key: {{ tls_key }}
   mongodb:
     name: {{ common_database_name }}
     url: {{ common_database_url }}

--- a/tests/unit/resources/expected_udrcfg.yaml
+++ b/tests/unit/resources/expected_udrcfg.yaml
@@ -8,6 +8,9 @@ configuration:
     registerIPv4: 1.2.3.4
     bindingIPv4: 0.0.0.0
     port: 29504
+    tls:
+      pem: /support/TLS/udr.pem
+      key: /support/TLS/udr.key
   mongodb:
     name: free5gc
     url: http://dummy

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -231,7 +231,7 @@ class TestCharmConfigure(UDRUnitTestFixtures):
                             "udr": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/bin/udr -udrcfg /free5gc/config/udrcfg.yaml",
+                                "command": "/bin/udr -cfg /free5gc/config/udrcfg.yaml",
                                 "environment": {
                                     "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
                                     "GRPC_GO_LOG_SEVERITY_LEVEL": "info",


### PR DESCRIPTION
# Description

- Bump rock image to fix grpc client reconnection
- The Upstream community updated how to specify the configuration path to run the NF service.
-  TLS paths are parameterized in the Upstream and we need to specify them in the configuration file.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library