### PR TITLE
feat: add NMS integration with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ juju integrate mongodb-k8s sdcore-udr-k8s:common_database
 juju integrate mongodb-k8s sdcore-udr-k8s:auth_database
 juju integrate sdcore-nms-k8s:common_database mongodb-k8s:database
 juju integrate sdcore-nms-k8s:auth_database mongodb-k8s:database
+juju integrate sdcore-nms-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:fiveg_nrf sdcore-udr-k8s:fiveg_nrf
 juju integrate sdcore-udr-k8s:certificates self-signed-certificates:certificates

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -127,6 +127,8 @@ class TestUDROperatorCharm:
         assert ops_test.model
         await self._deploy_tls_provider(ops_test)
         await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=TLS_CHARM_NAME)
+        await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_CHARM_NAME)
+        await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=TLS_CHARM_NAME)
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=300)
 
     @pytest.mark.skip(
@@ -197,8 +199,9 @@ class TestUDROperatorCharm:
             channel=NMS_CHARM_CHANNEL,
         )
         await ops_test.model.integrate(
-            relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DATABASE_CHARM_NAME}"
+            relation1=f"{NMS_CHARM_NAME}:common_database", relation2=DATABASE_CHARM_NAME
         )
         await ops_test.model.integrate(
-            relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DATABASE_CHARM_NAME}"
+            relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=DATABASE_CHARM_NAME
         )
+        await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_CHARM_NAME)


### PR DESCRIPTION
# Description

This PR adds the NMS integration with the TLS to the integration tests.
TLS certificates integration is mandatory for NMS and the NMS charm does not share the webui address until this relation exists.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library