### PR TITLE
chore: move to channel 6/stable in mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Charmed Operator for Aether SD-Core's Unified Data Repository (UDR) component 
 ## Usage
 
 ```bash
-juju deploy mongodb-k8s --trust --channel=6/beta
+juju deploy mongodb-k8s --trust --channel=6/stable
 juju deploy sdcore-nrf-k8s --channel=1.5/edge
 juju deploy sdcore-udr-k8s --channel=1.5/edge
 juju deploy self-signed-certificates

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -15,7 +15,7 @@ METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APPLICATION_NAME = METADATA["name"]
 
 DATABASE_CHARM_NAME = "mongodb-k8s"
-DATABASE_CHARM_CHANNEL = "6/beta"
+DATABASE_CHARM_CHANNEL = "6/stable"
 NRF_CHARM_NAME = "sdcore-nrf-k8s"
 NRF_CHARM_CHANNEL = "1.5/edge"
 NMS_CHARM_NAME = "sdcore-nms-k8s"
@@ -131,18 +131,14 @@ class TestUDROperatorCharm:
         await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=TLS_CHARM_NAME)
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=300)
 
-    @pytest.mark.skip(
-        reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
-    )
+
     @pytest.mark.abort_on_fail
     async def test_remove_database_and_wait_for_blocked_status(self, ops_test: OpsTest, deploy):
         assert ops_test.model
         await ops_test.model.remove_application(DATABASE_CHARM_NAME, block_until_done=True)
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)
 
-    @pytest.mark.skip(
-        reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
-    )
+
     @pytest.mark.abort_on_fail
     async def test_restore_database_and_wait_for_active_status(self, ops_test: OpsTest, deploy):
         assert ops_test.model

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -143,6 +143,14 @@ class TestUDROperatorCharm:
     async def test_restore_database_and_wait_for_active_status(self, ops_test: OpsTest, deploy):
         assert ops_test.model
         await self._deploy_mongodb(ops_test)
+        await ops_test.model.integrate(
+            relation1=f"{APPLICATION_NAME}:{COMMON_DATABASE_RELATION_NAME}",
+            relation2=DATABASE_CHARM_NAME,
+        )
+        await ops_test.model.integrate(
+            relation1=f"{APPLICATION_NAME}:{AUTH_DATABASE_RELATION_NAME}",
+            relation2=DATABASE_CHARM_NAME,
+        )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=300)
 
     @staticmethod


### PR DESCRIPTION
# Description

This PR sets the the `6/stable` channel for mongodb charm instead of `6/beta`
https://github.com/canonical/mongodb-k8s-operator/issues/218 seems fixed in `6/stable` so the tests can be restored

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library