### PR TITLE
feat: add log-level configuration option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -79,3 +79,10 @@ parts:
       rustup default stable
       uv export --frozen --no-dev -o requirements.txt
       craftctl default
+
+config:
+  options:
+    log-level:
+      type: string
+      default: info
+      description: Log level for the UDR. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

--- a/src/charm.py
+++ b/src/charm.py
@@ -675,10 +675,6 @@ class UDROperatorCharm(CharmBase):
             dict: environment variables
         """
         return {
-            "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-            "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-            "GRPC_TRACE": "all",
-            "GRPC_VERBOSITY": "debug",
             "MANAGED_BY_CONFIG_POD": "true",
             "POD_IP": _get_pod_ip(),
         }

--- a/src/templates/udrcfg.yaml.j2
+++ b/src/templates/udrcfg.yaml.j2
@@ -19,10 +19,6 @@ configuration:
   nrfUri: {{ nrf_url }}
   webuiUri: {{ webui_uri }}
 
-# the kind of log output
-# debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-# ReportCaller: enable the caller report or not, value: true or false
 logger:
   UDR:
-    debugLevel: info
-    ReportCaller: false
+    debugLevel: {{ log_level }}

--- a/tests/unit/resources/expected_udrcfg.yaml
+++ b/tests/unit/resources/expected_udrcfg.yaml
@@ -19,10 +19,6 @@ configuration:
   nrfUri: https://nrf-example.com:1234
   webuiUri: some-webui:7890
 
-# the kind of log output
-# debugLevel: how detailed to output, value: trace, debug, info, warn, error, fatal, panic
-# ReportCaller: enable the caller report or not, value: true or false
 logger:
   UDR:
     debugLevel: info
-    ReportCaller: false

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -22,6 +22,22 @@ class TestCharmCollectStatus(UDRUnitTestFixtures):
 
         assert state_out.unit_status == BlockedStatus("Scaling is not implemented for this charm")
 
+    def test_given_invalid_log_level_config_when_collect_unit_status_then_status_is_blocked(
+        self,
+    ):
+        container = testing.Container(name="udr", can_connect=True)
+        state_in = testing.State(
+            leader=True,
+            config={"log-level": "invalid"},
+            containers={container},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "The following configurations are not valid: ['log-level']"
+        )
+
     def test_given_relations_not_created_when_collect_unit_status_then_status_is_blocked(self):
         container = testing.Container(
             name="udr",

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -233,10 +233,6 @@ class TestCharmConfigure(UDRUnitTestFixtures):
                                 "override": "replace",
                                 "command": "/bin/udr -cfg /free5gc/config/udrcfg.yaml",
                                 "environment": {
-                                    "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-                                    "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-                                    "GRPC_TRACE": "all",
-                                    "GRPC_VERBOSITY": "debug",
                                     "MANAGED_BY_CONFIG_POD": "true",
                                     "POD_IP": "1.2.3.4",
                                 },


### PR DESCRIPTION
# Description

Here we add a `log-level` configuration option with a reasonable default value (`info`). The allowed options are the same as in the workload: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

## Rationale

In most deployments, the log level should be set to `info` to ensure the log quantity is reasonable. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library