### PR TITLE
fix: use ubuntu@24.04 in TF modules

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ resource "juju_application" "udr" {
     name     = "sdcore-udr-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config      = var.config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,12 @@ variable "revision" {
   default     = null
 }
 
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "units" {
   description = "Number of units to deploy"
   type        = number

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ COMMON_DATABASE_RELATION_NAME = "common_database"
 AUTH_DATABASE_RELATION_NAME = "auth_database"
 NRF_RELATION_NAME = "fiveg_nrf"
 TLS_RELATION_NAME = "certificates"
+SDCORE_CHARMS_BASE = "ubuntu@24.04"
 
 
 class TestUDROperatorCharm:
@@ -188,6 +189,7 @@ class TestUDROperatorCharm:
             NRF_CHARM_NAME,
             application_name=NRF_CHARM_NAME,
             channel=NRF_CHARM_CHANNEL,
+            base=SDCORE_CHARMS_BASE,
             trust=True,
         )
         await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=DATABASE_CHARM_NAME)
@@ -201,6 +203,7 @@ class TestUDROperatorCharm:
             NMS_CHARM_NAME,
             application_name=NMS_CHARM_NAME,
             channel=NMS_CHARM_CHANNEL,
+            base=SDCORE_CHARMS_BASE,
         )
         await ops_test.model.integrate(
             relation1=f"{NMS_CHARM_NAME}:common_database", relation2=DATABASE_CHARM_NAME

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -28,7 +28,7 @@ COMMON_DATABASE_RELATION_NAME = "common_database"
 AUTH_DATABASE_RELATION_NAME = "auth_database"
 NRF_RELATION_NAME = "fiveg_nrf"
 TLS_RELATION_NAME = "certificates"
-SDCORE_CHARMS_BASE = "ubuntu@24.04"
+SDCORE_CHARMS_SERIES = "noble"
 
 
 class TestUDROperatorCharm:
@@ -189,7 +189,7 @@ class TestUDROperatorCharm:
             NRF_CHARM_NAME,
             application_name=NRF_CHARM_NAME,
             channel=NRF_CHARM_CHANNEL,
-            base=SDCORE_CHARMS_BASE,
+            series=SDCORE_CHARMS_SERIES,  # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
             trust=True,
         )
         await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=DATABASE_CHARM_NAME)
@@ -203,7 +203,7 @@ class TestUDROperatorCharm:
             NMS_CHARM_NAME,
             application_name=NMS_CHARM_NAME,
             channel=NMS_CHARM_CHANNEL,
-            base=SDCORE_CHARMS_BASE,
+            series=SDCORE_CHARMS_SERIES,  # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
         )
         await ops_test.model.integrate(
             relation1=f"{NMS_CHARM_NAME}:common_database", relation2=DATABASE_CHARM_NAME


### PR DESCRIPTION
# Description

By default, Juju fetches charms with base matching the host OS. It means that when running Jammy, Juju won’t use latest charms, because we’ve changed the base to Noble.

Adding an optional (as per CC006) config param base will allow using Noble (base should be set to ubuntu@24.04) regardless of the host OS.

Enforcing Noble on a Juju model configuration level is not an option, because it breaks COS integration (COS charms are not available in ubuntu@24.04).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library