### PR TITLE
fix: remove update-lib step from v1.5 scheduled runs

### DIFF
--- a/.github/workflows/1_5_scheduled_runs.yaml
+++ b/.github/workflows/1_5_scheduled_runs.yaml
@@ -48,10 +48,3 @@ jobs:
     with:
       branch-name: "v1.5"
       enable-metallb: true
-
-  update-lib:
-    name: Check libraries
-    uses: canonical/sdcore-github-workflows/.github/workflows/update-libs.yaml@v2.2.0
-    with:
-      branch-name: "v1.5"
-    secrets: inherit


### PR DESCRIPTION
# Description

This PR removes the `update-lib` step from v1.5 scheduled runs CI.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library